### PR TITLE
FIX: size propagation when size changed twice

### DIFF
--- a/Sources/CrookedText/SizeKey.swift
+++ b/Sources/CrookedText/SizeKey.swift
@@ -13,6 +13,7 @@ internal struct PropagateSize<V: View>: View {
     var body: some View {
         GeometryReader { proxy in
             self.content()
+                .fixedSize()
                 .background(GeometryReader { proxy in
                     Color.clear.preference(key: TextViewSizeKey.self, value: [proxy.size])
                 })


### PR DESCRIPTION
Bugfix: Before, after changing the size twice (due to UI/screen conditions around, tested with smaller one and back to normal) only height got propagated correctly, width was wrong. Happened at least on iOS 17, maybe also on < iOS versions.